### PR TITLE
fix: 보고서 목록 레이아웃 개선

### DIFF
--- a/src/components/reports/ReportGrid.tsx
+++ b/src/components/reports/ReportGrid.tsx
@@ -1,13 +1,20 @@
-import { Report, ReportListProps } from '@/types/report';
+// src/components/reports/ReportGrid.tsx
+import { Report } from '@/types/report';
 import { format } from 'date-fns';
-import { Car } from 'lucide-react';
+import { Car, MapPin } from 'lucide-react';
 import { generateReportTitle, getStatusBadge } from '@/lib/utils/report';
 import Image from 'next/image';
 
-export default function ReportGrid({ reports, onSelectReport }: ReportListProps) {
+interface ReportListProps {
+  reports: Report[];
+  onSelectReport: (report: Report) => void;
+}
+
+export default function ReportList({ reports, onSelectReport }: ReportListProps) {
   return (
     <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
       {reports.map((report) => (
+        // src/components/reports/ReportGrid.tsx의 레이아웃 부분
         <div
           key={report.report_id}
           className="group cursor-pointer rounded-lg bg-white p-6 shadow-sm transition-all hover:shadow-md dark:bg-gray-800"
@@ -24,13 +31,16 @@ export default function ReportGrid({ reports, onSelectReport }: ReportListProps)
           <h3 className="mt-2 text-lg font-semibold text-gray-900 group-hover:text-primary dark:text-white dark:group-hover:text-primary">
             {generateReportTitle(report)}
           </h3>
-          <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">{report.location}</p>
-          <div className="mt-4 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
-            <span>{format(new Date(report.date), 'yyyy년 MM월 dd일')}</span>
+          <div className="mt-2 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+            <span>{format(new Date(report.date), 'yyyy.MM.dd')}</span>
             <div className="flex items-center gap-1">
               <Car className="h-4 w-4" />
               <span>{report.number_of_vehicle}대</span>
             </div>
+          </div>
+          <div className="mt-2 flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400">
+            <MapPin className="h-4 w-4" />
+            <span>{report.location}</span>
           </div>
           {report.fileType === 'image' && (
             <div className="mt-4 grid grid-cols-4 gap-2">

--- a/src/components/reports/ReportList.tsx
+++ b/src/components/reports/ReportList.tsx
@@ -1,10 +1,15 @@
 // src/components/reports/ReportList.tsx
-import { Report, ReportListProps } from '@/types/report';
+import { Report } from '@/types/report';
 import { format } from 'date-fns';
-import { Car } from 'lucide-react';
+import { Car, MapPin } from 'lucide-react';
 import { generateReportTitle, getStatusBadge } from '@/lib/utils/report';
 
-export default function ReportList({ reports, onSelectReport }: ReportListProps) {
+interface ReportGridProps {
+  reports: Report[];
+  onSelectReport: (report: Report) => void;
+}
+
+export default function ReportGrid({ reports, onSelectReport }: ReportGridProps) {
   return (
     <div className="rounded-lg bg-white shadow-sm dark:bg-gray-800">
       <div className="overflow-x-auto">
@@ -18,10 +23,13 @@ export default function ReportList({ reports, onSelectReport }: ReportListProps)
                 제목
               </th>
               <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                발생일
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
                 차량
               </th>
               <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                발생일
+                발생 위치
               </th>
               <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
                 심각도
@@ -42,9 +50,9 @@ export default function ReportList({ reports, onSelectReport }: ReportListProps)
                   <div className="text-sm font-medium text-gray-900 dark:text-white">
                     {generateReportTitle(report)}
                   </div>
-                  <div className="text-sm text-gray-500 dark:text-gray-400">
-                    {report.location}
-                  </div>
+                </td>
+                <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900 dark:text-white">
+                  {format(new Date(report.date), 'yyyy.MM.dd')}
                 </td>
                 <td className="whitespace-nowrap px-6 py-4">
                   <div className="flex items-center gap-1 text-sm text-gray-900 dark:text-white">
@@ -52,8 +60,11 @@ export default function ReportList({ reports, onSelectReport }: ReportListProps)
                     <span>{report.number_of_vehicle}대</span>
                   </div>
                 </td>
-                <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900 dark:text-white">
-                  {format(new Date(report.date), 'yyyy년 MM월 dd일')}
+                <td className="whitespace-nowrap px-6 py-4">
+                  <div className="flex items-center gap-1 text-sm text-gray-900 dark:text-white">
+                    <MapPin className="h-4 w-4" />
+                    <span>{report.location}</span>
+                  </div>
                 </td>
                 <td className="whitespace-nowrap px-6 py-4 text-sm">
                   <span className={getStatusBadge(report.accident_type.severity)}>

--- a/src/lib/utils/report.ts
+++ b/src/lib/utils/report.ts
@@ -17,7 +17,7 @@ export const generateReportTitle = (report: Report): string => {
     ? '심각한 ' 
     : '';
 
-  return `${location}에서 발생한 ${severityPrefix}${vehicleCount}${accidentType}`;
+  return `${location}에서 발생한 ${severityPrefix}${vehicleCount}${accidentType}사고`;
 };
 
 export const getStatusBadge = (severity: string) => {


### PR DESCRIPTION
## 보고서 목록 레이아웃 개선

### 변경사항
1. 그리드뷰 레이아웃 개선
   - 차량 대수와 날짜를 한 줄에 통합 배치
   - 위치 정보를 별도 줄로 분리하여 가독성 향상
   - 전반적인 여백과 정렬 조정

2. 리스트뷰 최적화
   - 정보 배치 순서 개선 (ID, 제목, 발생일, 차량, 위치, 심각도)
   - 각 열 너비 최적화

3. UI 스타일 개선
   - 심각도 뱃지 스타일 수정 (라이트모드 대응)
   - 전체적인 텍스트 색상 일관성 개선

### 테스트 항목
- [ ] 그리드뷰 레이아웃 확인
- [ ] 리스트뷰 열 배치 확인
- [ ] 라이트/다크 모드 호환성 확인
- [ ] 반응형 레이아웃 동작 확인

### 스크린샷