### PR TITLE
feat: 통계 페이지 구현

### DIFF
--- a/src/app/dashboard/statistics/page.tsx
+++ b/src/app/dashboard/statistics/page.tsx
@@ -1,0 +1,58 @@
+// src/app/dashboard/statistics/page.tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/context/AuthContext';
+import { reportsApi } from '@/lib/api/reports';
+import type { Report } from '@/types/report';
+import StatisticsOverview from '@/components/statistics/StatisticsOverview';
+import AccidentTrends from '@/components/statistics/AccidentTrends';
+import AccidentTypes from '@/components/statistics/AccidentTypes';
+import RegionalAnalysis from '@/components/statistics/RegionalAnalysis';
+import DetailedStats from '@/components/statistics/DetailedStats';
+
+export default function StatisticsPage() {
+  const { user } = useAuth();
+  const [reports, setReports] = useState<Report[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchReports = async () => {
+      try {
+        const reportsData = await reportsApi.getReports();
+        setReports(reportsData);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : '데이터 로딩 중 오류가 발생했습니다');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchReports();
+  }, []);
+
+  if (loading) return <div className="flex h-full items-center justify-center">로딩 중...</div>;
+  if (error) return <div className="text-red-500">{error}</div>;
+
+  return (
+    <div className="space-y-8 p-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">사고 통계</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          {user?.isMaster ? '전체 사고' : '내 사고'} 통계 분석 대시보드
+        </p>
+      </div>
+      
+      <StatisticsOverview reports={reports} />
+      
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <AccidentTrends reports={reports} />
+        <AccidentTypes reports={reports} />
+      </div>
+      
+      <RegionalAnalysis reports={reports} />
+      <DetailedStats reports={reports} />
+    </div>
+  );
+}

--- a/src/components/statistics/AccidentTrends.tsx
+++ b/src/components/statistics/AccidentTrends.tsx
@@ -1,0 +1,158 @@
+// src/components/statistics/AccidentTrends.tsx
+'use client';
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+} from 'recharts';
+import { useState } from 'react';
+import type { Report } from '@/types/report';
+
+interface AccidentTrendsProps {
+  reports: Report[];
+}
+
+export default function AccidentTrends({ reports }: AccidentTrendsProps) {
+  const [view, setView] = useState<'monthly' | 'weekly'>('monthly');
+
+  // 월별 데이터 계산
+  const getMonthlyData = () => {
+    const monthlyStats = reports.reduce((acc, report) => {
+      const date = new Date(report.date);
+      const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+      
+      if (!acc[monthKey]) {
+        acc[monthKey] = {
+          month: monthKey,
+          total: 0,
+          severe: 0,
+          moderate: 0,
+          minor: 0,
+        };
+      }
+      
+      acc[monthKey].total += 1;
+      switch (report.accident_type.severity) {
+        case '심각':
+          acc[monthKey].severe += 1;
+          break;
+        case '보통':
+          acc[monthKey].moderate += 1;
+          break;
+        case '경미':
+          acc[monthKey].minor += 1;
+          break;
+      }
+      
+      return acc;
+    }, {} as Record<string, any>);
+
+    return Object.values(monthlyStats).sort((a, b) => a.month.localeCompare(b.month));
+  };
+
+  // 요일별 데이터 계산
+  const getWeeklyData = () => {
+    const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+    const weeklyStats = reports.reduce((acc, report) => {
+      const date = new Date(report.date);
+      const day = weekdays[date.getDay()];
+      
+      if (!acc[day]) {
+        acc[day] = {
+          day,
+          count: 0,
+          severe: 0,
+        };
+      }
+      
+      acc[day].count += 1;
+      if (report.accident_type.severity === '심각') {
+        acc[day].severe += 1;
+      }
+      
+      return acc;
+    }, {} as Record<string, any>);
+
+    return weekdays.map(day => weeklyStats[day] || { day, count: 0, severe: 0 });
+  };
+
+  const monthlyData = getMonthlyData();
+  const weeklyData = getWeeklyData();
+
+  return (
+    <div className="rounded-xl bg-white p-6 shadow-sm dark:bg-gray-800">
+      <div className="mb-6 flex items-center justify-between">
+        <h3 className="text-base font-semibold text-gray-800 dark:text-white">
+          사고 발생 추이
+        </h3>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setView('monthly')}
+            className={`rounded-lg px-3 py-1 text-sm ${
+              view === 'monthly'
+                ? 'bg-primary text-white'
+                : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
+            }`}
+          >
+            월별
+          </button>
+          <button
+            onClick={() => setView('weekly')}
+            className={`rounded-lg px-3 py-1 text-sm ${
+              view === 'weekly'
+                ? 'bg-primary text-white'
+                : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
+            }`}
+          >
+            요일별
+          </button>
+        </div>
+      </div>
+
+      <div className="h-80">
+        <ResponsiveContainer width="100%" height="100%">
+          {view === 'monthly' ? (
+            <LineChart data={monthlyData}>
+              <CartesianGrid strokeDasharray="3 3" opacity={0.1} />
+              <XAxis dataKey="month" stroke="#94a3b8" fontSize={12} />
+              <YAxis stroke="#94a3b8" fontSize={12} />
+              <Tooltip />
+              <Line
+                type="monotone"
+                dataKey="total"
+                stroke="#6366f1"
+                name="전체"
+                strokeWidth={2}
+                dot={{ strokeWidth: 2 }}
+              />
+              <Line
+                type="monotone"
+                dataKey="severe"
+                stroke="#ef4444"
+                name="심각"
+                strokeWidth={2}
+                dot={{ strokeWidth: 2 }}
+              />
+            </LineChart>
+          ) : (
+            <BarChart data={weeklyData}>
+              <CartesianGrid strokeDasharray="3 3" opacity={0.1} />
+              <XAxis dataKey="day" stroke="#94a3b8" fontSize={12} />
+              <YAxis stroke="#94a3b8" fontSize={12} />
+              <Tooltip />
+              <Bar dataKey="count" fill="#6366f1" name="전체 사고" />
+              <Bar dataKey="severe" fill="#ef4444" name="심각 사고" />
+            </BarChart>
+          )}
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/statistics/AccidentTypes.tsx
+++ b/src/components/statistics/AccidentTypes.tsx
@@ -1,0 +1,168 @@
+// src/components/statistics/AccidentTypes.tsx
+'use client';
+
+import { useState } from 'react';
+import { PieChart, Pie, Cell, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
+import type { Report } from '@/types/report';
+
+interface AccidentTypesProps {
+  reports: Report[];
+}
+
+const COLORS = ['#3b82f6', '#ef4444', '#f59e0b', '#10b981', '#6366f1', '#8b5cf6'];
+
+export default function AccidentTypes({ reports }: AccidentTypesProps) {
+  const [activeIndex, setActiveIndex] = useState<number | undefined>();
+
+  // 사고 유형별 통계
+  const getAccidentTypeStats = () => {
+    const stats = reports.reduce((acc, report) => {
+      const type = report.accident_type?.type || '기타';
+      if (!acc[type]) {
+        acc[type] = {
+          name: type,
+          value: 0,
+          severe: 0,
+          moderate: 0,
+          minor: 0
+        };
+      }
+      acc[type].value += 1;
+      
+      // 심각도별 카운트
+      switch (report.accident_type?.severity) {
+        case '심각':
+          acc[type].severe += 1;
+          break;
+        case '보통':
+          acc[type].moderate += 1;
+          break;
+        case '경미':
+          acc[type].minor += 1;
+          break;
+      }
+      
+      return acc;
+    }, {} as Record<string, any>);
+
+    return Object.values(stats);
+  };
+
+  const typeStats = getAccidentTypeStats();
+
+  // 심각도별 통계 데이터
+  const severityData = typeStats.map(stat => ({
+    name: stat.name,
+    심각: stat.severe,
+    보통: stat.moderate,
+    경미: stat.minor
+  }));
+
+  const onPieEnter = (_: any, index: number) => {
+    setActiveIndex(index);
+  };
+
+  const customTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="rounded-lg bg-white p-3 shadow-lg dark:bg-gray-800">
+          <p className="mb-2 font-medium">{label}</p>
+          {payload.map((item: any, index: number) => (
+            <p key={index} className="text-sm" style={{ color: item.fill }}>
+              {item.name}: {item.value}건
+            </p>
+          ))}
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div className="rounded-xl bg-white p-6 shadow-sm dark:bg-gray-800">
+      <h3 className="mb-6 text-base font-semibold text-gray-800 dark:text-white">
+        사고 유형 분석
+      </h3>
+      
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* 도넛 차트 */}
+        <div className="h-[300px]">
+          <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">사고 유형 분포</p>
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={typeStats}
+                cx="50%"
+                cy="50%"
+                innerRadius={60}
+                outerRadius={80}
+                fill="#8884d8"
+                paddingAngle={5}
+                dataKey="value"
+                onMouseEnter={onPieEnter}
+              >
+                {typeStats.map((entry, index) => (
+                  <Cell 
+                    key={`cell-${index}`}
+                    fill={COLORS[index % COLORS.length]}
+                    opacity={activeIndex === index ? 0.8 : 1}
+                  />
+                ))}
+              </Pie>
+              <Tooltip
+                content={({ active, payload }) => {
+                  if (active && payload && payload.length) {
+                    const data = payload[0].payload;
+                    return (
+                      <div className="rounded-lg bg-white p-3 shadow-lg dark:bg-gray-800">
+                        <p className="font-medium">{data.name}</p>
+                        <p className="text-sm text-gray-500">
+                          {data.value}건 ({((data.value / reports.length) * 100).toFixed(1)}%)
+                        </p>
+                      </div>
+                    );
+                  }
+                  return null;
+                }}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* 스택 바 차트 */}
+        <div className="h-[300px]">
+          <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">유형별 심각도 분포</p>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={severityData}
+              layout="vertical"
+              margin={{ top: 0, right: 0, left: 40, bottom: 0 }}
+            >
+              <XAxis type="number" />
+              <YAxis dataKey="name" type="category" width={80} />
+              <Tooltip content={customTooltip} />
+              <Bar dataKey="심각" stackId="a" fill="#ef4444" />
+              <Bar dataKey="보통" stackId="a" fill="#f59e0b" />
+              <Bar dataKey="경미" stackId="a" fill="#10b981" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* 범례 */}
+        <div className="col-span-full mt-4 flex flex-wrap justify-center gap-4">
+          {typeStats.map((stat, index) => (
+            <div key={stat.name} className="flex items-center gap-2">
+              <div
+                className="h-3 w-3 rounded-full"
+                style={{ backgroundColor: COLORS[index % COLORS.length] }}
+              />
+              <span className="text-sm text-gray-600 dark:text-gray-300">
+                {stat.name} ({stat.value}건)
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/statistics/DetailedStats.tsx
+++ b/src/components/statistics/DetailedStats.tsx
@@ -1,0 +1,244 @@
+// src/components/statistics/DetailedStats.tsx
+'use client';
+
+import { useState, useMemo } from 'react';
+import { Calendar, Search, ArrowUpDown } from 'lucide-react';
+import type { Report } from '@/types/report';
+
+interface DetailedStatsProps {
+  reports: Report[];
+}
+
+type SortKey = 'date' | 'location' | 'severity' | 'vehicles';
+type SortOrder = 'asc' | 'desc';
+
+export default function DetailedStats({ reports }: DetailedStatsProps) {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [sortConfig, setSortConfig] = useState<{key: SortKey; order: SortOrder}>({
+    key: 'date',
+    order: 'desc'
+  });
+  const [selectedPeriod, setSelectedPeriod] = useState<'all' | 'month' | 'week'>('all');
+  const [selectedSeverity, setSelectedSeverity] = useState<string>('all');
+
+  // 날짜 필터링
+  const filterByDate = (reports: Report[]) => {
+    const now = new Date();
+    const msPerDay = 24 * 60 * 60 * 1000;
+    
+    return reports.filter(report => {
+      const reportDate = new Date(report.date);
+      const daysDiff = Math.floor((now.getTime() - reportDate.getTime()) / msPerDay);
+
+      switch (selectedPeriod) {
+        case 'week':
+          return daysDiff <= 7;
+        case 'month':
+          return daysDiff <= 30;
+        default:
+          return true;
+      }
+    });
+  };
+
+  // 정렬 및 필터링된 데이터
+  const filteredReports = useMemo(() => {
+    let filtered = filterByDate(reports);
+
+    // 심각도 필터링
+    if (selectedSeverity !== 'all') {
+      filtered = filtered.filter(
+        report => report.accident_type?.severity === selectedSeverity
+      );
+    }
+
+    // 검색어 필터링
+    if (searchTerm) {
+      const term = searchTerm.toLowerCase();
+      filtered = filtered.filter(
+        report =>
+          report.location.toLowerCase().includes(term) ||
+          report.description.toLowerCase().includes(term) ||
+          report.accident_type.type.toLowerCase().includes(term)
+      );
+    }
+
+    // 정렬
+    return filtered.sort((a, b) => {
+      switch (sortConfig.key) {
+        case 'date':
+          return sortConfig.order === 'desc'
+            ? new Date(b.date).getTime() - new Date(a.date).getTime()
+            : new Date(a.date).getTime() - new Date(b.date).getTime();
+        case 'location':
+          return sortConfig.order === 'desc'
+            ? b.location.localeCompare(a.location)
+            : a.location.localeCompare(b.location);
+        case 'severity':
+          const severityOrder = { '심각': 3, '보통': 2, '경미': 1 };
+          return sortConfig.order === 'desc'
+            ? severityOrder[b.accident_type.severity as keyof typeof severityOrder] - 
+              severityOrder[a.accident_type.severity as keyof typeof severityOrder]
+            : severityOrder[a.accident_type.severity as keyof typeof severityOrder] - 
+              severityOrder[b.accident_type.severity as keyof typeof severityOrder];
+        case 'vehicles':
+          return sortConfig.order === 'desc'
+            ? b.number_of_vehicle - a.number_of_vehicle
+            : a.number_of_vehicle - b.number_of_vehicle;
+        default:
+          return 0;
+      }
+    });
+  }, [reports, searchTerm, sortConfig, selectedPeriod, selectedSeverity]);
+
+  const handleSort = (key: SortKey) => {
+    setSortConfig(prev => ({
+      key,
+      order: prev.key === key && prev.order === 'desc' ? 'asc' : 'desc'
+    }));
+  };
+
+  return (
+    <div className="rounded-xl bg-white p-6 shadow-sm dark:bg-gray-800">
+      <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <h3 className="text-base font-semibold text-gray-800 dark:text-white">
+          상세 통계
+        </h3>
+
+        <div className="flex flex-wrap gap-3">
+          {/* 기간 필터 */}
+          <div className="flex items-center gap-2">
+            <Calendar className="h-4 w-4 text-gray-500" />
+            <select
+              value={selectedPeriod}
+              onChange={(e) => setSelectedPeriod(e.target.value as 'all' | 'month' | 'week')}
+              className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm dark:border-gray-700 dark:bg-gray-800"
+            >
+              <option value="all">전체 기간</option>
+              <option value="month">최근 1개월</option>
+              <option value="week">최근 1주일</option>
+            </select>
+          </div>
+
+          {/* 심각도 필터 */}
+          <select
+            value={selectedSeverity}
+            onChange={(e) => setSelectedSeverity(e.target.value)}
+            className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm dark:border-gray-700 dark:bg-gray-800"
+          >
+            <option value="all">모든 심각도</option>
+            <option value="심각">심각</option>
+            <option value="보통">보통</option>
+            <option value="경미">경미</option>
+          </select>
+
+          {/* 검색 */}
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" />
+            <input
+              type="text"
+              placeholder="검색..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="rounded-lg border border-gray-200 bg-white pl-9 pr-3 py-1.5 text-sm dark:border-gray-700 dark:bg-gray-800"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* 테이블 */}
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[800px] border-collapse">
+          <thead>
+            <tr className="border-b border-gray-200 dark:border-gray-700">
+              <th 
+                onClick={() => handleSort('date')}
+                className="cursor-pointer py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400"
+              >
+                <div className="flex items-center gap-1">
+                  날짜
+                  <ArrowUpDown className="h-4 w-4" />
+                </div>
+              </th>
+              <th 
+                onClick={() => handleSort('location')}
+                className="cursor-pointer py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400"
+              >
+                <div className="flex items-center gap-1">
+                  위치
+                  <ArrowUpDown className="h-4 w-4" />
+                </div>
+              </th>
+              <th 
+                onClick={() => handleSort('severity')}
+                className="cursor-pointer py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400"
+              >
+                <div className="flex items-center gap-1">
+                  심각도
+                  <ArrowUpDown className="h-4 w-4" />
+                </div>
+              </th>
+              <th 
+                onClick={() => handleSort('vehicles')}
+                className="cursor-pointer py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400"
+              >
+                <div className="flex items-center gap-1">
+                  관련 차량
+                  <ArrowUpDown className="h-4 w-4" />
+                </div>
+              </th>
+              <th className="py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400">
+                사고 내용
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredReports.map((report) => (
+              <tr
+                key={report.report_id}
+                className="border-b border-gray-200 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/50"
+              >
+                <td className="py-3 text-sm text-gray-600 dark:text-gray-300">
+                  {new Date(report.date).toLocaleDateString()}
+                </td>
+                <td className="py-3 text-sm text-gray-600 dark:text-gray-300">
+                  {report.location}
+                </td>
+                <td className="py-3 text-sm">
+                  <span
+                    className={`rounded-full px-2 py-1 text-xs font-medium ${
+                      report.accident_type.severity === '심각'
+                        ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
+                        : report.accident_type.severity === '보통'
+                        ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400'
+                        : 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                    }`}
+                  >
+                    {report.accident_type.severity}
+                  </span>
+                </td>
+                <td className="py-3 text-sm text-gray-600 dark:text-gray-300">
+                  {report.number_of_vehicle}대
+                </td>
+                <td className="max-w-md py-3 text-sm text-gray-600 dark:text-gray-300">
+                  <p className="truncate">{report.description}</p>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {filteredReports.length === 0 && (
+          <div className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+            데이터가 없습니다
+          </div>
+        )}
+      </div>
+
+      {/* 페이지 요약 */}
+      <div className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+        총 {filteredReports.length}건의 사고 데이터
+      </div>
+    </div>
+  );
+}

--- a/src/components/statistics/RegionalAnalysis.tsx
+++ b/src/components/statistics/RegionalAnalysis.tsx
@@ -1,0 +1,237 @@
+// src/components/statistics/RegionalAnalysis.tsx
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  CartesianGrid,
+} from 'recharts';
+import { ArrowUpDown } from 'lucide-react';
+import type { Report } from '@/types/report';
+
+interface RegionalAnalysisProps {
+  reports: Report[];
+}
+
+interface RegionData {
+  region: string;
+  total: number;
+  severe: number;
+  moderate: number;
+  minor: number;
+  recentAccident?: string;
+  avgSeverity: number;
+}
+
+export default function RegionalAnalysis({ reports }: RegionalAnalysisProps) {
+  const [sortBy, setSortBy] = useState<'total' | 'severe'>('total');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+
+  // 지역별 데이터 계산
+  const regionData = useMemo(() => {
+    const data: Record<string, RegionData> = {};
+
+    reports.forEach(report => {
+      // 첫 번째 행정구역 추출 (예: "서울시 강남구" -> "서울")
+      const region = report.location.split(' ')[0];
+
+      if (!data[region]) {
+        data[region] = {
+          region,
+          total: 0,
+          severe: 0,
+          moderate: 0,
+          minor: 0,
+          avgSeverity: 0,
+        };
+      }
+
+      data[region].total += 1;
+
+      // 심각도별 카운트
+      switch (report.accident_type?.severity) {
+        case '심각':
+          data[region].severe += 1;
+          break;
+        case '보통':
+          data[region].moderate += 1;
+          break;
+        case '경미':
+          data[region].minor += 1;
+          break;
+      }
+
+      // 가장 최근 사고 정보 업데이트
+      const accidentDate = new Date(report.date);
+      if (
+        !data[region].recentAccident ||
+        accidentDate > new Date(data[region].recentAccident)
+      ) {
+        data[region].recentAccident = report.date;
+      }
+
+      // 평균 심각도 계산 (심각: 3, 보통: 2, 경미: 1)
+      data[region].avgSeverity =
+        (data[region].severe * 3 + data[region].moderate * 2 + data[region].minor) /
+        data[region].total;
+    });
+
+    return Object.values(data);
+  }, [reports]);
+
+  // 정렬된 데이터
+  const sortedData = useMemo(() => {
+    return [...regionData].sort((a, b) => {
+      const compareValue = sortOrder === 'desc' ? b[sortBy] - a[sortBy] : a[sortBy] - b[sortBy];
+      return compareValue;
+    });
+  }, [regionData, sortBy, sortOrder]);
+
+  // 정렬 토글
+  const toggleSort = (key: 'total' | 'severe') => {
+    if (sortBy === key) {
+      setSortOrder(sortOrder === 'desc' ? 'asc' : 'desc');
+    } else {
+      setSortBy(key);
+      setSortOrder('desc');
+    }
+  };
+
+  const customTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div className="rounded-lg bg-white p-4 shadow-lg dark:bg-gray-800">
+          <p className="mb-2 font-semibold">{label}</p>
+          <div className="space-y-1 text-sm">
+            <p className="text-blue-500">총 사고: {data.total}건</p>
+            <p className="text-red-500">심각 사고: {data.severe}건</p>
+            <p className="text-yellow-500">보통 사고: {data.moderate}건</p>
+            <p className="text-green-500">경미 사고: {data.minor}건</p>
+            <p className="mt-2 text-gray-500">
+              최근 사고: {new Date(data.recentAccident).toLocaleDateString()}
+            </p>
+          </div>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div className="rounded-xl bg-white p-6 shadow-sm dark:bg-gray-800">
+      <div className="mb-6 flex items-center justify-between">
+        <h3 className="text-base font-semibold text-gray-800 dark:text-white">지역별 분석</h3>
+        <div className="flex gap-2">
+          <button
+            onClick={() => toggleSort('total')}
+            className={`flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm transition-colors ${
+              sortBy === 'total'
+                ? 'bg-primary text-white'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
+            }`}
+          >
+            총 건수
+            <ArrowUpDown className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => toggleSort('severe')}
+            className={`flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm transition-colors ${
+              sortBy === 'severe'
+                ? 'bg-primary text-white'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
+            }`}
+          >
+            심각 사고
+            <ArrowUpDown className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* 차트 */}
+      <div className="h-80">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={sortedData}
+            margin={{ top: 20, right: 30, left: 40, bottom: 10 }}
+            barSize={20}
+          >
+            <CartesianGrid strokeDasharray="3 3" opacity={0.1} />
+            <XAxis dataKey="region" />
+            <YAxis />
+            <Tooltip content={customTooltip} />
+            <Bar dataKey="total" fill="#3b82f6">
+              {sortedData.map((entry, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={`rgba(59, 130, 246, ${0.5 + (entry.avgSeverity / 3) * 0.5})`}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* 지역별 상세 통계 테이블 */}
+      <div className="mt-6 overflow-x-auto">
+        <table className="w-full min-w-[600px] border-collapse">
+          <thead>
+            <tr className="border-b border-gray-200 dark:border-gray-700">
+              <th className="py-3 text-left text-sm font-medium text-gray-500 dark:text-gray-400">
+                지역
+              </th>
+              <th className="py-3 text-right text-sm font-medium text-gray-500 dark:text-gray-400">
+                총 사고
+              </th>
+              <th className="py-3 text-right text-sm font-medium text-gray-500 dark:text-gray-400">
+                심각
+              </th>
+              <th className="py-3 text-right text-sm font-medium text-gray-500 dark:text-gray-400">
+                보통
+              </th>
+              <th className="py-3 text-right text-sm font-medium text-gray-500 dark:text-gray-400">
+                경미
+              </th>
+              <th className="py-3 text-right text-sm font-medium text-gray-500 dark:text-gray-400">
+                최근 사고
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedData.map((data) => (
+              <tr
+                key={data.region}
+                className="border-b border-gray-200 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/50"
+              >
+                <td className="py-3 text-sm font-medium text-gray-900 dark:text-white">
+                  {data.region}
+                </td>
+                <td className="py-3 text-right text-sm text-gray-600 dark:text-gray-300">
+                  {data.total}건
+                </td>
+                <td className="py-3 text-right text-sm text-red-600 dark:text-red-400">
+                  {data.severe}건
+                </td>
+                <td className="py-3 text-right text-sm text-yellow-600 dark:text-yellow-400">
+                  {data.moderate}건
+                </td>
+                <td className="py-3 text-right text-sm text-green-600 dark:text-green-400">
+                  {data.minor}건
+                </td>
+                <td className="py-3 text-right text-sm text-gray-600 dark:text-gray-300">
+                  {new Date(data.recentAccident!).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/statistics/StatisticsOverview.tsx
+++ b/src/components/statistics/StatisticsOverview.tsx
@@ -1,0 +1,112 @@
+// src/components/statistics/StatisticsOverview.tsx
+'use client';
+
+import { Car, AlertTriangle, Users, Calendar } from 'lucide-react';
+import type { Report } from '@/types/report';
+
+interface StatCardProps {
+ title: string;
+ value: number | string;
+ icon: React.ElementType;
+ description?: string;
+ trend?: number;
+ colorClass: string;
+}
+
+const StatCard = ({ title, value, icon: Icon, description, colorClass }: StatCardProps) => (
+ <div className={`rounded-xl ${colorClass} p-6 shadow-sm`}>
+   <div className="flex items-start justify-between">
+     <div>
+       <p className="text-sm font-medium text-white">{title}</p>
+       <p className="mt-2 text-3xl font-bold text-white">{value}</p>
+       {description && (
+         <p className="mt-1 text-xs text-white/70">{description}</p>
+       )}
+     </div>
+     <span className="rounded-lg bg-white/10 p-2.5">
+       <Icon className="h-6 w-6 text-white" />
+     </span>
+   </div>
+ </div>
+);
+
+interface StatisticsOverviewProps {
+ reports: Report[];
+}
+
+export default function StatisticsOverview({ reports }: StatisticsOverviewProps) {
+ // 통계 계산
+ const calculateStats = () => {
+   const totalAccidents = reports.length;
+   
+   // 심각 사고 건수
+   const severeCases = reports.filter(r => 
+     r.accident_type && r.accident_type.severity === '심각'
+   ).length;
+   
+   // 고유한 날짜 수
+   const uniqueDates = new Set(reports.map(r => r.date.split('T')[0])).size;
+   
+   // 부상자/사망자 수 계산
+   const casualties = reports.reduce((acc, report) => {
+     if (!report.damaged_situation) {
+       return acc;
+     }
+
+     const injuryText = report.damaged_situation.damage;
+     const deaths = injuryText.match(/사망자\s*(\d+)명/);
+     const injuries = injuryText.match(/(중상자|경상자)\s*(\d+)명/g);
+     
+     acc.deaths += deaths ? parseInt(deaths[1]) : 0;
+     if (injuries) {
+       injuries.forEach(injury => {
+         const count = parseInt(injury.match(/\d+/)?.[0] || '0');
+         acc.injuries += count;
+       });
+     }
+     return acc;
+   }, { deaths: 0, injuries: 0 });
+
+   return {
+     totalAccidents,
+     severeCases,
+     uniqueDates,
+     casualties
+   };
+ };
+
+ const stats = calculateStats();
+
+ return (
+   <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
+     <StatCard
+       title="총 사고 건수"
+       value={stats.totalAccidents}
+       icon={Car}
+       colorClass="bg-gradient-to-br from-blue-600 to-blue-700"
+       description="전체 분석된 사고 수"
+     />
+     <StatCard
+       title="심각 사고"
+       value={stats.severeCases}
+       icon={AlertTriangle}
+       colorClass="bg-gradient-to-br from-red-600 to-red-700"
+       description={`전체의 ${((stats.severeCases / stats.totalAccidents) * 100).toFixed(1)}%`}
+     />
+     <StatCard
+       title="총 사상자"
+       value={`${stats.casualties.deaths + stats.casualties.injuries}명`}
+       icon={Users}
+       colorClass="bg-gradient-to-br from-amber-600 to-amber-700"
+       description={`사망 ${stats.casualties.deaths}명, 부상 ${stats.casualties.injuries}명`}
+     />
+     <StatCard
+       title="분석 일수"
+       value={stats.uniqueDates}
+       icon={Calendar}
+       colorClass="bg-gradient-to-br from-emerald-600 to-emerald-700"
+       description="총 분석된 날짜 수"
+     />
+   </div>
+ );
+}

--- a/src/types/auth/index.ts
+++ b/src/types/auth/index.ts
@@ -13,4 +13,5 @@ export interface UserProfile {
   nickname: string;
   profileImage?: string;
   userType: 'user' | 'admin';
+  isMaster: boolean;  // 추가
 }


### PR DESCRIPTION
# 통계 페이지 구현

## 구현 내용
현재 DB에 저장된 사고 보고서 데이터를 기반으로 다양한 통계 분석 기능을 제공하는 페이지를 구현했습니다.

### 1. Overview 섹션
- 총 사고 건수
- 심각 사고 비율
- 총 사상자 수 (사망자/부상자 구분)
- 전체 분석 일수
를 한눈에 볼 수 있는 카드 형태로 제공

### 2. 사고 유형 분석
- 도넛 차트: 사고 유형별 분포 시각화
- 스택 바 차트: 각 유형별 심각도 분포 표시
- 인터랙티브 툴팁으로 상세 정보 확인 가능

### 3. 지역별 분석
- 지역별 사고 발생 현황을 바 차트로 시각화
- 심각도에 따른 색상 강도 차등 적용
- 상세 통계 테이블에서 지역별 세부 정보 제공
- 총 건수/심각 사고 기준 정렬 기능

### 4. 상세 통계 테이블
- 전체 사고 데이터를 테이블 형태로 제공
- 필터링 기능:
  - 기간별 (전체/1개월/1주일)
  - 심각도별
  - 검색어 기반
- 정렬 기능:
  - 날짜
  - 위치
  - 심각도
  - 관련 차량 수

## 데이터 처리
- Report DB의 다음 필드들을 활용:
  - `date`: 사고 발생 일시
  - `location`: 사고 발생 위치
  - `accident_type`: 사고 유형 및 심각도
  - `damaged_situation`: 인명 피해 상황
  - `number_of_vehicle`: 관련 차량 수
  - `description`: 사고 상세 설명

## 권한 처리
- 일반 사용자: 본인의 사고 데이터에 대한 통계만 확인 가능
- Master 계정: 전체 사고 데이터에 대한 통계 확인 가능


## 테스트 방법
1. Master 계정으로 로그인하여 전체 통계 확인
2. 일반 계정으로 로그인하여 개인 통계 확인
3. 각 차트의 인터랙션 테스트
4. 필터링 및 정렬 기능 테스트

## 스크린샷
![image](https://github.com/user-attachments/assets/b57509ed-e80c-4a74-af09-ec4e7cc4f023)
![image](https://github.com/user-attachments/assets/436a978b-e15d-41d5-a002-2163868217c7)
![image](https://github.com/user-attachments/assets/446d0d52-763e-4ce2-98f3-d540828946b8)


## 관련 이슈
